### PR TITLE
Adjusting RNG and number ranges

### DIFF
--- a/src/SQEQGenerator.cpp
+++ b/src/SQEQGenerator.cpp
@@ -140,7 +140,7 @@ std::pair<std::string, std::string> SQEQGenerator::GetTask() const
 //                                           >=		<= 
 int SQEQGenerator::GetRandomSignedNumInRange(int min, int max) const
 {
-	int x = (min - 1) + (rand() % (max - min + 1));
+	int x = min + (rand() % (max - min + 1));
 
 	/* Get a random sign for x with probability 1/2 */
 	if (rand() % 2)

--- a/src/SQEQGenerator.cpp
+++ b/src/SQEQGenerator.cpp
@@ -121,7 +121,9 @@ std::pair<std::string, std::string> SQEQGenerator::GetTask() const
 	std::stringstream task, answer;
 
 	x1 = GetRandomSignedNumInRange(X1_MIN_VALUE, MaxX1);
-	x2 = GetRandomSignedNumInRange(X2_MIN_VALUE, MaxX2);
+	x2 = GetRandomSignedNumInRange(X2_MIN_VALUE, MaxX2 - 1);
+ 	if(x2 == -x1) // Exclude incomplete equations
+		x2 = MaxX2;
 	a = GetRandomSignedNumInRange(A_MIN_VALUE, MaxA);
 	b = -a*(x1 + x2);
 	c = -a * x1 * x2;


### PR DESCRIPTION
- x1 and x2 cannot be opposite anymore, which means there won't be any incomplete equations where b = 0;
- Fixed RNG returning the number lower than the minimum value by one and never returning the number lower than the maximum value by one.